### PR TITLE
Fixed DS import button not showing in Foundry v11

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,13 +2,13 @@
   "name": "dungeon-scrawl-importer",
   "title": "Dungeon Scrawl Importer",
   "description": "A Foundry module to allow importing a .ds file generated with Dungeon Scrawl to automatically generate walls.",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "library": "false",
-  "manifestPlusVersion": "1.3.1",
+  "manifestPlusVersion": "1.3.3",
   "minimumCoreVersion": "10",
   "compatibility": {
     "minimum": 10,
-    "verified": 10
+    "verified": 11
   },
   "authors": [
     {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,7 +1,7 @@
 import {DungeonScrawlImporterFormApplication} from "./DungeonScrawlImporterFormApplication.js"
 
 Hooks.on('renderSidebarTab', async function (app, html) {
-    if (app.options.id === "scenes" && game.user.isGM) {
+    if (app.options.classes.includes("scenes-sidebar") && game.user.isGM) {
         let button = $(`<div class='header-actions action-buttons flexrow'><button><i class='fas fa-file-import'></i> ${game.i18n.localize("DSI.button")}</button></div>`)
         button.on('click', async () => {
             if (!game.users.current.isGM) {


### PR DESCRIPTION
Changed the way the scene sidebar is referenced 